### PR TITLE
Fix build for Rust 1.3 (not test stuff)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-#![feature(core, test, str_char)]
+#[cfg(test)]
 extern crate test;
+
 /*
 pub mod intrinsics {
     use std::ptr;
@@ -45,7 +46,6 @@ pub mod intrinsics {
 
 /// Swap bytes for `u8` slices on all targets.
 pub mod u8 {
-    use std::num::Int;
     use std::ptr;
     use std::mem;
     use std::error;
@@ -56,7 +56,7 @@ pub mod u8 {
     #[inline]
     pub unsafe fn align_of_ptr(src: *const u8) -> usize {
         let off: usize = mem::transmute(src);
-        2.pow(off.trailing_zeros() as u32)
+        (2 as usize).pow(off.trailing_zeros() as u32)
     }
 
     /// TODO
@@ -69,8 +69,8 @@ pub mod u8 {
     #[inline]
     pub fn reverse_slice(dst: &mut [u8], src: &[u8]) {
         unsafe {
-            ptr::copy_nonoverlapping(dst.as_mut_ptr(),
-                                            src.as_ptr(),
+            ptr::copy_nonoverlapping(src.as_ptr(),
+                                            dst.as_mut_ptr(),
                                             src.len());
         }
         dst.reverse();
@@ -124,7 +124,7 @@ pub mod u8 {
     }
 
     /// Errors that can occur when decoding a hex encoded string
-    #[derive(Copy)]
+    #[derive(Copy,Clone)]
     pub enum FromHexError {
         /// The input contained a character not part of the hex format
         InvalidHexCharacter(char, usize),
@@ -168,7 +168,7 @@ pub mod u8 {
                     buf >>= 4;
                     continue
                 }
-                _ => return Err(FromHexError::InvalidHexCharacter(src.char_at(idx), idx)),
+                _ => return Err(FromHexError::InvalidHexCharacter(str::chars(src).nth(idx).unwrap(), idx)),
             }
 
             modulus += 1;
@@ -354,7 +354,6 @@ pub mod u56 {
 /// Swap bytes for `u32` objects on all targets.
 pub mod u32 {
     use std::cmp;
-    use std::num::Int;
     pub const BYTES: usize = 4;
 
 
@@ -428,7 +427,6 @@ pub mod u32 {
 /// Swap bytes for `u64` objects on all targets.
 pub mod u64 {
     use std::cmp;
-    use std::num::Int;
     pub const BYTES: usize = 7;
 
     /// Swaps `len*8` bytes for `u64` objects inplace in `buf`.
@@ -505,7 +503,6 @@ pub mod u64 {
 }
 
 pub mod beusize {
-    use std::num::Int;
     use std::ptr;
     use std::mem;
 
@@ -517,7 +514,7 @@ pub mod beusize {
         let ptr_out = dst.as_mut_ptr();
         unsafe {
             ptr::copy_nonoverlapping(
-                ptr_out.offset((8 - nbytes) as isize), src.as_ptr(), nbytes);
+                src.as_ptr(), ptr_out.offset((8 - nbytes) as isize), nbytes);
             (*(ptr_out as *const u64)).to_be()
         }
     }
@@ -530,13 +527,12 @@ pub mod beusize {
             // n.b. https://github.com/rust-lang/rust/issues/22776
             let bytes: [u8; 8] = mem::transmute::<_, [u8; 8]>(src.to_be());
             ptr::copy_nonoverlapping(
-                dst.as_mut_ptr(), (&bytes[8 - nbytes..]).as_ptr(), nbytes);
+                (&bytes[8 - nbytes..]).as_ptr(), dst.as_mut_ptr(), nbytes);
         }
     }
 }
 
 pub mod leusize {
-    use std::num::Int;
     use std::ptr;
     use std::mem;
 
@@ -548,7 +544,7 @@ pub mod leusize {
         let ptr_out = dst.as_mut_ptr();
         unsafe {
             ptr::copy_nonoverlapping(
-                ptr_out, src.as_ptr(), nbytes);
+                src.as_ptr(), ptr_out, nbytes);
             (*(ptr_out as *const u64)).to_le()
         }
     }
@@ -561,7 +557,7 @@ pub mod leusize {
             // n.b. https://github.com/rust-lang/rust/issues/22776
             let bytes: [u8; 8] = mem::transmute::<_, [u8; 8]>(src.to_le());
             ptr::copy_nonoverlapping(
-                dst.as_mut_ptr(), (&bytes[..nbytes]).as_ptr(), nbytes);
+                (&bytes[..nbytes]).as_ptr(), dst.as_mut_ptr(), nbytes);
         }
     }
 }
@@ -569,7 +565,6 @@ pub mod leusize {
 
 macro_rules! mod_odd_impls {
     ($I:ident, $T:ident, $S:ident, $Bytes:expr, $DFunc:ident, $EMeth:ident, $E:expr, $NotE:expr) => {
-        use std::num::Int;
         use std::ptr;
         use std::mem;
 
@@ -578,7 +573,7 @@ macro_rules! mod_odd_impls {
             if cfg!(target_endian = $NotE) {
                 super::$T::swap_memory(dst, src, len);
             } else {
-                ptr::copy_nonoverlapping(dst, src, len*$Bytes);
+                ptr::copy_nonoverlapping(src, dst, len*$Bytes);
             }
         }
 
@@ -588,8 +583,8 @@ macro_rules! mod_odd_impls {
             assert_eq!(buf.len(), $Bytes);
             unsafe {
                 let mut tmp: $S = mem::uninitialized();
-                ptr::copy_nonoverlapping(&mut tmp as *mut _ as *mut u8, buf.as_ptr(), $Bytes);
-                Int::$DFunc(tmp)
+                ptr::copy_nonoverlapping(buf.as_ptr(), &mut tmp as *mut _ as *mut u8, $Bytes);
+                $S::$DFunc(tmp)
             }
         }
 
@@ -608,7 +603,7 @@ macro_rules! mod_odd_impls {
             assert_eq!(dst.len(), $Bytes);
             unsafe {
                 let tmp: $S = src.$EMeth();
-                ptr::copy_nonoverlapping(dst.as_mut_ptr(), &tmp as *const _ as *const u8, $Bytes);
+                ptr::copy_nonoverlapping(&tmp as *const _ as *const u8, dst.as_mut_ptr(), $Bytes);
             }
         }
 
@@ -626,7 +621,6 @@ macro_rules! mod_odd_impls {
 
 macro_rules! mod_std_impls {
     ($I:ident, $T:ident, $Bytes:expr, $DFunc:ident, $EMeth:ident, $E:expr, $NotE:expr) => {
-        use std::num::Int;
         use std::ptr;
         use std::mem;
 
@@ -635,7 +629,7 @@ macro_rules! mod_std_impls {
             if cfg!(target_endian = $NotE) {
                 super::$T::swap_memory(dst, src, len);
             } else {
-                ptr::copy_nonoverlapping(dst, src, len*$Bytes);
+                ptr::copy_nonoverlapping(src, dst, len*$Bytes);
             }
         }
 
@@ -645,8 +639,8 @@ macro_rules! mod_std_impls {
             assert_eq!(buf.len(), $Bytes);
             unsafe {
                 let mut tmp: $T = mem::uninitialized();
-                ptr::copy_nonoverlapping(&mut tmp as *mut _ as *mut u8, buf.as_ptr(), $Bytes);
-                Int::$DFunc(tmp)
+                ptr::copy_nonoverlapping(buf.as_ptr(), &mut tmp as *mut _ as *mut u8, $Bytes);
+                $T::$DFunc(tmp)
             }
         }
 
@@ -665,7 +659,7 @@ macro_rules! mod_std_impls {
             assert_eq!(dst.len(), $Bytes);
             unsafe {
                 let tmp: $T = src.$EMeth();
-                ptr::copy_nonoverlapping(dst.as_mut_ptr(), &tmp as *const _ as *const u8, $Bytes);
+                ptr::copy_nonoverlapping(&tmp as *const _ as *const u8, dst.as_mut_ptr(), $Bytes);
             }
         }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -156,7 +156,7 @@ fn test_u64_swap_memory_hi() {
 fn test_u64_swap_memory_inplace_hi() {
     let mut dst = [0u8; 8];
     let src: &[u8] = b"hi world";
-    ::std::slice::bytes::copy_memory(&mut dst, src);
+    ::std::slice::bytes::copy_memory(src, &mut dst);
     unsafe {
         super::u64::swap_memory_inplace(
             (&mut dst[..]).as_mut_ptr(),
@@ -185,7 +185,7 @@ fn test_u64_swap_memory_pangram() {
 fn test_u64_swap_memory_inplace_pangram() {
     let mut dst = [0u8; 32];
     let src: &[u8] = b"Five boxing wizards jump quickly";
-    ::std::slice::bytes::copy_memory(&mut dst, src);
+    ::std::slice::bytes::copy_memory(src, &mut dst);
     unsafe {
         super::u64::swap_memory_inplace(
             (&mut dst[..]).as_mut_ptr(),
@@ -215,7 +215,7 @@ fn test_u64_swap_memory_lorem_ipsum() {
 fn test_u64_swap_memory_inplace_lorem_ipsum() {
     let mut dst = [0u8; 160];
     let src: &[u8] = &LOREM_IPSUM[..160];
-    ::std::slice::bytes::copy_memory(&mut dst, src);
+    ::std::slice::bytes::copy_memory(src, &mut dst);
     unsafe {
         super::u64::swap_memory_inplace(
             (&mut dst[..]).as_mut_ptr(),


### PR DESCRIPTION
Fixes compile errors when building. Couldn't test because the `test` crate does not appear to exist and I couldn't find any doc on `test::Bencher`.
